### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Homestead.yaml
 Thumbs.db
 *.iml
 .idea/
+
+app/storage

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,19 @@
+/bootstrap/compiled.php
 /vendor
+
 /node_modules
+
 Homestead.yaml
-.env
+
 .DS_Store
 Thumbs.db
+
 *.iml
 .idea/
 
 app/storage
+
+.env
+
+composer.phar
+


### PR DESCRIPTION
app/storage is created on deployement with the right chmod options and should not be in version control.